### PR TITLE
Fixing #132 - fix accident subtype lookup

### DIFF
--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -76,7 +76,7 @@ var SidebarView = Backbone.View.extend({
 
                 var entryHtml = this.sidebarItemTemplate({
                     created: moment(markerModel.get("created")).format("LLLL"),
-                    type: SUBTYPE_STRING[markerModel.get("subtype")],
+                    type: SUBTYPE_STRING[markerModel.get("subtype") - 1],
                     icon: markerView.getIcon()
                 });
 


### PR DESCRIPTION
After the extraction of locatilization.py, there was changes to the index of the accident types.

Maybe we need to expose the localization object through api? What do you think?
