### PR TITLE
Implement slack channel newsflash notificatications

### DIFF
--- a/anyway/parsers/news_flash_db_adapter.py
+++ b/anyway/parsers/news_flash_db_adapter.py
@@ -1,10 +1,12 @@
 import datetime
+import os
 import logging
 import pandas as pd
 from flask_sqlalchemy import SQLAlchemy
 from anyway.parsers import infographics_data_cache_updater
 from anyway.parsers import timezones
 from anyway.models import NewsFlash
+from anyway.slack_accident_notifications import publish_notification
 
 # fmt: off
 
@@ -76,6 +78,8 @@ class DBAdapter:
         self.db.session.add(newsflash)
         self.db.session.commit()
         infographics_data_cache_updater.add_news_flash_to_cache(newsflash)
+        if os.environ.get("FLASK_ENV") == "production":
+            publish_notification(newsflash)
 
     def get_newsflash_by_id(self, id):
         return self.db.session.query(NewsFlash).filter(NewsFlash.id == id)

--- a/anyway/slack_accident_notifications.py
+++ b/anyway/slack_accident_notifications.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, asdict
+from typing import List
+
+import requests
+from anyway import secrets
+
+from anyway.models import NewsFlash
+from anyway.parsers.infographics_data_cache_updater import is_in_cache
+
+INFOGRAPHIC_URL = "https://media.anyway.co.il/newsflash/"
+
+
+@dataclass
+class Text:
+    type: str
+    text: str
+
+
+@dataclass
+class Block:
+    type: str
+    text: Text
+
+
+@dataclass
+class Notification:
+    blocks: List[Block]
+
+
+def fmt_lnk_mrkdwn(url: str, text: str = "") -> str:
+    if text:
+        return f"<{url}|{text}>"
+    return f"<{url}>"
+
+
+def gen_notification(newsflash: NewsFlash) -> Notification:
+    blocks = []
+    title = Block(type="section", text=Text(type="plain_text", text=newsflash.title))
+    blocks.append(title)
+    if is_in_cache(newsflash):
+        infographic_link = Block(
+            type="section",
+            text=Text(
+                type="mrkdwn",
+                text=fmt_lnk_mrkdwn(f"{INFOGRAPHIC_URL}{newsflash.id}", "infographic"),
+            ),
+        )
+        blocks.append(infographic_link)
+    return Notification(blocks=blocks)
+
+
+def publish_notification(newsflash: NewsFlash):
+    notification = gen_notification(newsflash)
+    requests.post(secrets.get("SLACK_WEBHOOK_URL"), json=asdict(notification))


### PR DESCRIPTION
This is an initial implementation of a news flash notification system to ANYWAY's Slack channel.
For this inital build, each time the ETL process scrapes the sources for newsflashes a notification will be 
sent to an appropriate ANYWAY's Slack channel with the description and a link to the infographic of the newsflash (a link will only be included if the newsflash exists in the infographics cache).

Planned future improvements include:
- Only publish specific newsflashes that meet a chosen criteria (high number of fatalities on the road segment etc...)
- Provide additional information aside from description and link