### PR TITLE
make sure street is str

### DIFF
--- a/anyway/parsers/cbs/executor.py
+++ b/anyway/parsers/cbs/executor.py
@@ -699,7 +699,7 @@ def get_files(directory):
                             field_names.street_sign: x[field_names.street_sign],
                             field_names.street_name: x[field_names.street_name],
                         }
-                        for _, x in settlement.iterrows()
+                        for _, x in settlement.iterrows() if isinstance(x[field_names.street_name], str)
                     ]
 
                 output_files_dict[name] = streets_map


### PR DESCRIPTION
Should fix following bug in CBS data loading
```[2023-05-06, 21:35:37 UTC] {subprocess.py:93} INFO - Traceback: Traceback (most recent call last):
[2023-05-06, 21:35:37 UTC] {subprocess.py:93} INFO -   File "/anyway/anyway/parsers/cbs/executor.py", line 1236, in main
[2023-05-06, 21:35:37 UTC] {subprocess.py:93} INFO -     import_streets_into_db()
[2023-05-06, 21:35:37 UTC] {subprocess.py:93} INFO -   File "/anyway/anyway/parsers/cbs/executor.py", line 770, in import_streets_into_db
[2023-05-06, 21:35:37 UTC] {subprocess.py:93} INFO -     name_len = len(street_hebrew)
[2023-05-06, 21:35:37 UTC] {subprocess.py:93} INFO - TypeError: object of type 'float' has no len()```