### PR TITLE
Fix - #2398 - injured_count_by_severity_widget transcription

### DIFF
--- a/anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py
+++ b/anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py
@@ -90,7 +90,7 @@ class InjuredCountBySeverityWidget(RoadSegmentWidget):
             severity_severe_count_text = f'{severity_severe_count} '+  _("severe injured plural")
         killed_count = items.get("killed_count")
         if killed_count == 0:
-            killed_count = ''
+            killed_count_text = ''
         elif killed_count == 1:
             killed_count_text = _("one killed")
         else:


### PR DESCRIPTION
Fix the widget transcription issue where the bug causes the "injured_count_by_severity" widget to crash when the killed count is zero.