### PR TITLE
Implement todos in code

### DIFF
--- a/anyway/widgets/road_segment_widgets/top_road_segments_accidents_per_km_widget.py
+++ b/anyway/widgets/road_segment_widgets/top_road_segments_accidents_per_km_widget.py
@@ -31,6 +31,7 @@ class TopRoadSegmentsAccidentsPerKmWidget(RoadSegmentWidget):
             end_time=self.request_params.end_time,
         )
 
+    # noinspection PyUnresolvedReferences
     @staticmethod
     def get_top_road_segments_accidents_per_km(
         resolution, location_info, start_time=None, end_time=None, limit=3

--- a/anyway/widgets/widget_utils.py
+++ b/anyway/widgets/widget_utils.py
@@ -20,6 +20,9 @@ from anyway.widgets.segment_junctions import SegmentJunctions
 
 
 def get_query(table_obj, filters, start_time, end_time):
+    if "road_segment_name" in filters and "road_segment_id" in filters:
+        filters = copy.copy(filters)
+        filters.pop("road_segment_name")
     query = db.session.query(table_obj)
     if start_time:
         query = query.filter(getattr(table_obj, "accident_timestamp") >= start_time)
@@ -234,6 +237,7 @@ def sort_and_fill_gaps_for_stacked_bar(
     return res2
 
 
+# noinspection PyUnresolvedReferences
 def get_involved_counts(
     start_year: int,
     end_year: int,


### PR DESCRIPTION
 Remove road_segment_name from query if road_segment_id is present. 
closes #2503 
Remove warning about sqlalchemy filter column operator. Removed by suppressing the warning in the function. The implementation follows the documentation.
closes #2507 