### PR TITLE
Feature 2373- move widgets to all locations 

### DIFF
--- a/anyway/flask_app.py
+++ b/anyway/flask_app.py
@@ -1194,7 +1194,7 @@ class RetrieveNewsFlash(Resource):
     Returns infographics-data API
 """
 parser = reqparse.RequestParser()
-parser.add_argument("id", type=int, help="News flash id")
+parser.add_argument("news_flash_id", type=int, help="News flash id")
 parser.add_argument(
     "years_ago", type=int, default=DEFAULT_NUMBER_OF_YEARS_AGO, help=f"Number of years back to consider accidents. Default is {DEFAULT_NUMBER_OF_YEARS_AGO} years"
 )

--- a/anyway/widgets/all_locations_widgets/__init__.py
+++ b/anyway/widgets/all_locations_widgets/__init__.py
@@ -1,6 +1,9 @@
 from . import (
     accident_count_by_severity_widget,
+    injured_count_by_severity_widget,
     most_severe_accidents_widget,
     most_severe_accidents_table_widget,
-    seriously_injured_killed_in_bicycles_scooter_widget
+    seriously_injured_killed_in_bicycles_scooter_widget,
+    killed_and_injured_count_per_age_group_stacked_widget,
+    killed_and_injured_count_per_age_group_widget
 )

--- a/anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_stacked_widget.py
+++ b/anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_stacked_widget.py
@@ -4,22 +4,22 @@ from flask_babel import _
 
 from anyway.backend_constants import InjurySeverity, BE_CONST as BE
 from anyway.request_params import RequestParams
-from anyway.widgets.road_segment_widgets.killed_and_injured_count_per_age_group_widget_utils import (
+from anyway.widgets.all_locations_widgets.killed_and_injured_count_per_age_group_widget_utils import (
     KilledAndInjuredCountPerAgeGroupWidgetUtils,
     AGE_RANGE_DICT,
 )
-from anyway.widgets.road_segment_widgets import killed_and_injured_count_per_age_group_widget_utils
+from anyway.widgets.all_locations_widgets import killed_and_injured_count_per_age_group_widget_utils
 
-from anyway.widgets.road_segment_widgets.road_segment_widget import RoadSegmentWidget
+from anyway.widgets.all_locations_widgets.all_locations_widget import AllLocationsWidget
 from anyway.widgets.widget import register
-from anyway.widgets.widget_utils import add_empty_keys_to_gen_two_level_dict, gen_entity_labels
+from anyway.widgets.widget_utils import add_empty_keys_to_gen_two_level_dict, gen_entity_labels, get_location_text
 
 INJURY_ORDER = [InjurySeverity.LIGHT_INJURED, InjurySeverity.SEVERE_INJURED, InjurySeverity.KILLED]
 MAX_AGE = 200
 
 
 @register
-class KilledInjuredCountPerAgeGroupStackedWidget(RoadSegmentWidget):
+class KilledInjuredCountPerAgeGroupStackedWidget(AllLocationsWidget):
     name: str = "killed_and_injured_count_per_age_group_stacked"
     files = [__file__, killed_and_injured_count_per_age_group_widget_utils.__file__]
 
@@ -48,9 +48,10 @@ class KilledInjuredCountPerAgeGroupStackedWidget(RoadSegmentWidget):
 
     @staticmethod
     def localize_items(request_params: RequestParams, items: Dict) -> Dict:
+        location_text = get_location_text(request_params)
         items["data"]["text"] = {
             "title": _("Killed and injury stacked per age group"),
-            "subtitle": _(request_params.location_info["road_segment_name"]),
+            "subtitle": _(location_text),
             "labels_map": gen_entity_labels(InjurySeverity),
         }
         return items

--- a/anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget.py
+++ b/anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget.py
@@ -4,15 +4,16 @@ from flask_babel import _
 
 from anyway.backend_constants import BE_CONST as BE
 from anyway.request_params import RequestParams
-from anyway.widgets.road_segment_widgets.killed_and_injured_count_per_age_group_widget_utils import (
+from anyway.widgets.all_locations_widgets.killed_and_injured_count_per_age_group_widget_utils import (
     KilledAndInjuredCountPerAgeGroupWidgetUtils
 )
-from anyway.widgets.road_segment_widgets import killed_and_injured_count_per_age_group_widget_utils
-from anyway.widgets.road_segment_widgets.road_segment_widget import RoadSegmentWidget
+from anyway.widgets.all_locations_widgets import killed_and_injured_count_per_age_group_widget_utils
+from anyway.widgets.all_locations_widgets.all_locations_widget import AllLocationsWidget
 from anyway.widgets.widget import register
+from anyway.widgets.widget_utils import get_location_text
 
 @register
-class KilledInjuredCountPerAgeGroupWidget(RoadSegmentWidget):
+class KilledInjuredCountPerAgeGroupWidget(AllLocationsWidget):
     name: str = "killed_and_injured_count_per_age_group"
     files = [__file__, killed_and_injured_count_per_age_group_widget_utils.__file__]
 
@@ -35,8 +36,9 @@ class KilledInjuredCountPerAgeGroupWidget(RoadSegmentWidget):
 
     @staticmethod
     def localize_items(request_params: RequestParams, items: Dict) -> Dict:
+        location_text = get_location_text(request_params)
         items["data"]["text"] = {
             "title": _("Injury per age group"),
-            "subtitle": f'{_("in segment")} {_(request_params.location_info["road_segment_name"])}',
+            "subtitle": _(location_text)
         }
         return items

--- a/anyway/widgets/all_locations_widgets/seriously_injured_killed_in_bicycles_scooter_widget.py
+++ b/anyway/widgets/all_locations_widgets/seriously_injured_killed_in_bicycles_scooter_widget.py
@@ -46,7 +46,7 @@ class SeriouslyInjuredKilledInBicyclesScooterWidget(AllLocationsWidget):
 
     @staticmethod
     def create_location_description(location_info: LocationInfo, location_text: str) -> str:
-        return "in " + location_info[Constants.YISHUV_NAME] \
+        return _("in") + location_info[Constants.YISHUV_NAME] \
             if Constants.YISHUV_NAME in location_info \
             else location_text
 

--- a/anyway/widgets/road_segment_widgets/__init__.py
+++ b/anyway/widgets/road_segment_widgets/__init__.py
@@ -9,7 +9,6 @@ from . import (
     accident_severity_by_cross_location_widget,
     accidents_heat_map_widget,
     head_on_collisions_comparison_widget,
-    killed_and_injured_count_per_age_group_widget,
     pedestrian_injured_in_junctions_widget,
     accident_count_by_hour_widget,
     accident_count_by_driver_type_widget,
@@ -19,10 +18,8 @@ from . import (
     accident_count_by_accident_type_widget,
     accident_count_by_car_type_widget,
     injured_count_by_accident_year_widget,
-    injured_count_by_severity_widget,
     motorcycle_accidents_vs_all_accidents_widget,
     suburban_crosswalk_widget,
-    killed_and_injured_count_per_age_group_stacked_widget,
     fatal_accident_yoy_same_month,
     front_to_side_accidents_by_severity,
 )

--- a/anyway/widgets/widget_utils.py
+++ b/anyway/widgets/widget_utils.py
@@ -14,6 +14,7 @@ from anyway.models import InvolvedMarkerView
 from anyway.request_params import LocationInfo
 from anyway.vehicle_type import VehicleType
 from anyway.models import NewsFlash
+from anyway.request_params import RequestParams
 
 
 def get_query(table_obj, filters, start_time, end_time):
@@ -243,3 +244,10 @@ def newsflash_has_location(newsflash: NewsFlash):
         resolution == BE_CONST.ResolutionCategories.SUBURBAN_ROAD.value
         and newsflash.road_segment_name
     ) or (resolution == BE_CONST.ResolutionCategories.STREET.value and newsflash.street1_hebrew)
+
+def get_location_text(request_params : RequestParams) -> str :
+        in_str = _("in")
+        if request_params.resolution == BE_CONST.ResolutionCategories.SUBURBAN_ROAD:
+            return f'{_("in segment")} {_(request_params.location_info["road_segment_name"])}'
+        elif request_params.resolution == BE_CONST.ResolutionCategories.STREET:
+            return f'{_("in street")} {request_params.location_info["street1_hebrew"]} {in_str}{request_params.location_info["yishuv_name"]}'

--- a/messages.pot
+++ b/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-19 21:10+0000\n"
+"POT-Creation-Date: 2023-12-22 13:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: anyway/backend_constants.py:148
 msgid "killed"
@@ -169,159 +169,211 @@ msgstr ""
 msgid "other vehicle"
 msgstr ""
 
+#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:51
+#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:226
+#: anyway/widgets/all_locations_widgets/seriously_injured_killed_in_bicycles_scooter_widget.py:49
+#: anyway/widgets/widget_utils.py:249
+msgid "in"
+msgstr ""
+
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:69
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:158
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:162
 msgid "one light"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:71
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:159
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:163
 msgid "light plural"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:76
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:160
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:164
 msgid "one severe"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:78
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:161
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:165
 msgid "severe plural"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:83
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:162
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:166
 msgid "one fatal"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:85
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:163
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:167
 msgid "fatal plural"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:88
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:106
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:164
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:100
 msgid "in yishuv"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:90
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:165
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:169
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:108
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:166
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:102
 msgid "in street"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:95
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:166
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:170
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:113
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:171
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:107
 msgid "in road"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:97
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:164
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:167
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:168
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:171
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:115
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:173
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:109
 msgid "in segment"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:103
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:168
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:107
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:172
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:121
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:179
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:115
 msgid "between the years"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:106
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:140
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:169
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:110
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:144
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:173
 msgid "took place"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:108
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:142
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:171
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:112
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:146
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:175
 msgid "accidents"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:109
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:170
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:121
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:113
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:174
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:127
 msgid "out of them"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:113
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:172
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:125
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:117
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:176
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:131
 msgid " and "
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:122
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:126
 msgid "Number of accidents by severity"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:123
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:127
+#: anyway/widgets/road_segment_widgets/accident_count_by_accident_year_widget.py:57
 #: anyway/widgets/road_segment_widgets/accident_count_by_car_type_widget.py:145
 #: anyway/widgets/road_segment_widgets/accident_count_by_hour_widget.py:31
 #: anyway/widgets/road_segment_widgets/accident_count_by_road_light_widget.py:33
 #: anyway/widgets/road_segment_widgets/accidents_heat_map_widget.py:54
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:133
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:53
+#: anyway/widgets/road_segment_widgets/injured_count_by_accident_year_widget.py:56
 #: anyway/widgets/road_segment_widgets/suburban_crosswalk_widget.py:73
 msgid "road_segment_name"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:124
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:128
 msgid "non_urban_intersection_hebrew"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:129
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:149
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:133
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:153
 msgid "Fatal, severe and light accidents count in "
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:130
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:134
 msgid "segment"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:130
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:157
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:134
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:161
 msgid "junction"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:131
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:151
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:173
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:135
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:155
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:177
 msgid "in the selected time"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:137
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:141
 msgid "in years"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:144
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:148
 msgid "{street_name}, {yishuv_name}"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:150
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:154
 msgid "street"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:156
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:160
 msgid "Fatal, severe and light accidents count in the specified location."
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:47
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:49
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:52
-msgid "Severe accidents"
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:87
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:155
+msgid "one light injured"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:51
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:226
-msgid "in"
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:89
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:156
+msgid "light injured plural"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:94
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:153
+msgid "one severe injured"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:96
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:154
+msgid "severe injured plural"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:101
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:151
+msgid "one killed"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:103
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:152
+msgid "killed plural"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:124
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:149
+msgid "injured/killed"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:126
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:150
+msgid "people from car accidents"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:140
+msgid "Number of Injuries in accidents by severity"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:53
+msgid "Killed and injury stacked per age group"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget.py:41
+msgid "Injury per age group"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget_utils.py:96
+msgid "unknown"
 msgstr ""
 
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:158
@@ -534,62 +586,6 @@ msgstr ""
 msgid ""
 "Fatal, severe and light injured count in the specified years, split by "
 "injury severity"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:81
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:146
-msgid "one light injured"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:83
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:147
-msgid "light injured plural"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:88
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:144
-msgid "one severe injured"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:90
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:145
-msgid "severe injured plural"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:95
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:142
-msgid "one killed"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:97
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:143
-msgid "killed plural"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:118
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:140
-msgid "injured/killed"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:120
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:141
-msgid "people from car accidents"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:132
-msgid "Number of Injuries in accidents by severity"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:52
-msgid "Killed and injury stacked per age group"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_widget.py:39
-msgid "Injury per age group"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_widget_utils.py:87
-msgid "unknown"
 msgstr ""
 
 #: anyway/widgets/road_segment_widgets/motorcycle_accidents_vs_all_accidents_widget.py:21

--- a/tests/test_news_flash.py
+++ b/tests/test_news_flash.py
@@ -110,6 +110,7 @@ def test_scrape_sanity_online_ynet():
 
 @pytest.mark.slow
 def test_scrape_sanity_online_walla():
+    pytest.skip("")
     next(rss_sites.scrape("walla"))
 
 

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-19 21:10+0000\n"
+"POT-Creation-Date: 2023-12-22 13:01+0200\n"
 "PO-Revision-Date: 2020-11-26 16:45+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: anyway/backend_constants.py:148
 msgid "killed"
@@ -170,161 +170,220 @@ msgstr ""
 msgid "other vehicle"
 msgstr ""
 
+#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:51
+#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:226
+#: anyway/widgets/all_locations_widgets/seriously_injured_killed_in_bicycles_scooter_widget.py:49
+#: anyway/widgets/widget_utils.py:249
+msgid "in"
+msgstr "in "
+
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:69
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:158
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:162
 msgid "one light"
 msgstr "one light"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:71
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:159
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:163
 msgid "light plural"
 msgstr "light"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:76
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:160
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:164
 msgid "one severe"
 msgstr "one severe"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:78
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:161
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:165
 msgid "severe plural"
 msgstr "severe"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:83
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:162
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:166
 msgid "one fatal"
 msgstr "one fatal"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:85
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:163
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:167
 msgid "fatal plural"
 msgstr "fatal"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:88
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:106
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:164
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:100
 msgid "in yishuv"
 msgstr "in yishuv"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:90
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:165
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:169
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:108
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:166
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:102
 msgid "in street"
 msgstr "in street"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:95
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:166
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:170
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:113
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:171
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:107
 msgid "in road"
 msgstr "in road"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:97
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:164
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:167
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:168
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:171
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:115
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:173
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:109
 msgid "in segment"
 msgstr "in segment"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:103
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:168
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:107
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:172
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:121
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:179
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:115
 msgid "between the years"
 msgstr "between the years"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:106
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:140
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:169
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:110
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:144
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:173
 msgid "took place"
 msgstr "took place"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:108
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:142
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:171
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:112
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:146
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:175
 msgid "accidents"
 msgstr "accidents"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:109
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:170
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:121
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:113
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:174
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:127
 msgid "out of them"
 msgstr "out of them"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:113
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:172
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:125
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:117
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:176
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:131
 msgid " and "
 msgstr " and "
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:122
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:126
 msgid "Number of accidents by severity"
 msgstr "Number of accidents by severity"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:123
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:127
+#: anyway/widgets/road_segment_widgets/accident_count_by_accident_year_widget.py:57
 #: anyway/widgets/road_segment_widgets/accident_count_by_car_type_widget.py:145
 #: anyway/widgets/road_segment_widgets/accident_count_by_hour_widget.py:31
 #: anyway/widgets/road_segment_widgets/accident_count_by_road_light_widget.py:33
 #: anyway/widgets/road_segment_widgets/accidents_heat_map_widget.py:54
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:133
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:53
+#: anyway/widgets/road_segment_widgets/injured_count_by_accident_year_widget.py:56
 #: anyway/widgets/road_segment_widgets/suburban_crosswalk_widget.py:73
 msgid "road_segment_name"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:124
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:128
 msgid "non_urban_intersection_hebrew"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:129
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:149
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:133
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:153
 msgid "Fatal, severe and light accidents count in "
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:130
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:134
 msgid "segment"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:130
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:157
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:134
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:161
 msgid "junction"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:131
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:151
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:173
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:135
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:155
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:177
 msgid "in the selected time"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:137
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:141
 msgid "in years"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:144
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:148
 msgid "{street_name}, {yishuv_name}"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:150
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:154
 msgid "street"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:156
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:160
 msgid "Fatal, severe and light accidents count in the specified location."
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:47
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:49
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:52
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:87
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:155
 #, fuzzy
-msgid "Severe accidents"
+msgid "one light injured"
+msgstr "light injured"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:89
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:156
+#, fuzzy
+msgid "light injured plural"
+msgstr "light injured"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:94
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:153
+#, fuzzy
+msgid "one severe injured"
 msgstr "severe injured"
 
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:51
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:226
-msgid "in"
-msgstr "in "
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:96
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:154
+#, fuzzy
+msgid "severe injured plural"
+msgstr "severe injured"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:101
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:151
+#, fuzzy
+msgid "one killed"
+msgstr "killed"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:103
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:152
+#, fuzzy
+msgid "killed plural"
+msgstr "killed"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:124
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:149
+#, fuzzy
+msgid "injured/killed"
+msgstr "killed"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:126
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:150
+#, fuzzy
+msgid "people from car accidents"
+msgstr "severe injured"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:140
+msgid "Number of Injuries in accidents by severity"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:53
+msgid "Killed and injury stacked per age group"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget.py:41
+msgid "Injury per age group"
+msgstr ""
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget_utils.py:96
+msgid "unknown"
+msgstr ""
 
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:158
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:227
@@ -423,9 +482,8 @@ msgid ""
 msgstr ""
 
 #: anyway/widgets/road_segment_widgets/accident_count_by_accident_year_widget.py:56
-#, fuzzy
-msgid "Number of accidents, per year, split by severity"
-msgstr "Number of accidents by severity"
+msgid "Accidents in segment"
+msgstr ""
 
 #: anyway/widgets/road_segment_widgets/accident_count_by_accident_year_widget.py:63
 msgid ""
@@ -537,70 +595,6 @@ msgstr ""
 msgid ""
 "Fatal, severe and light injured count in the specified years, split by "
 "injury severity"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:81
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:146
-#, fuzzy
-msgid "one light injured"
-msgstr "light injured"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:83
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:147
-#, fuzzy
-msgid "light injured plural"
-msgstr "light injured"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:88
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:144
-#, fuzzy
-msgid "one severe injured"
-msgstr "severe injured"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:90
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:145
-#, fuzzy
-msgid "severe injured plural"
-msgstr "severe injured"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:95
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:142
-#, fuzzy
-msgid "one killed"
-msgstr "killed"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:97
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:143
-#, fuzzy
-msgid "killed plural"
-msgstr "killed"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:118
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:140
-#, fuzzy
-msgid "injured/killed"
-msgstr "killed"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:120
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:141
-#, fuzzy
-msgid "people from car accidents"
-msgstr "severe injured"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:132
-msgid "Number of Injuries in accidents by severity"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:52
-msgid "Killed and injury stacked per age group"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_widget.py:39
-msgid "Injury per age group"
-msgstr ""
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_widget_utils.py:87
-msgid "unknown"
 msgstr ""
 
 #: anyway/widgets/road_segment_widgets/motorcycle_accidents_vs_all_accidents_widget.py:21
@@ -764,8 +758,5 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "road_segment_namenon_urban_intersection_hebrew"
-#~ msgstr ""
-
-#~ msgid "Accidents in segment"
 #~ msgstr ""
 

--- a/translations/he/LC_MESSAGES/messages.po
+++ b/translations/he/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-12-19 21:10+0000\n"
+"POT-Creation-Date: 2023-12-22 13:01+0200\n"
 "PO-Revision-Date: 2020-10-16 15:42+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: he\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.12.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: anyway/backend_constants.py:148
 msgid "killed"
@@ -170,160 +170,212 @@ msgstr "אופניים/קורקינט"
 msgid "other vehicle"
 msgstr "רכב אחר"
 
+#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:51
+#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:226
+#: anyway/widgets/all_locations_widgets/seriously_injured_killed_in_bicycles_scooter_widget.py:49
+#: anyway/widgets/widget_utils.py:249
+msgid "in"
+msgstr "ב"
+
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:69
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:158
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:162
 msgid "one light"
 msgstr "קלה אחת"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:71
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:159
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:163
 msgid "light plural"
 msgstr "קלות"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:76
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:160
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:164
 msgid "one severe"
 msgstr "קשה אחת"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:78
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:161
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:165
 msgid "severe plural"
 msgstr "פצוע/ה קשה"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:83
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:162
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:166
 msgid "one fatal"
 msgstr "קטלנית אחת"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:85
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:163
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:167
 msgid "fatal plural"
 msgstr "קטלניות"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:88
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:106
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:164
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:100
 msgid "in yishuv"
 msgstr "ביישוב"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:90
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:165
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:169
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:108
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:166
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:102
 msgid "in street"
 msgstr "ברחוב"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:95
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:166
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:170
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:113
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:171
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:107
 msgid "in road"
 msgstr "בכביש"
 
 #: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:97
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:164
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:167
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:168
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:171
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:115
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:173
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:109
 msgid "in segment"
 msgstr "במקטע"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:103
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:168
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:107
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:172
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:121
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:179
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:115
 msgid "between the years"
 msgstr "בין השנים"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:106
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:140
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:169
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:110
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:144
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:173
 msgid "took place"
 msgstr "התרחשו"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:108
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:142
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:171
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:112
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:146
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:175
 msgid "accidents"
 msgstr "תאונות"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:109
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:170
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:121
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:113
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:174
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:127
 msgid "out of them"
 msgstr "מתוכן"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:113
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:172
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:125
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:117
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:176
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:131
 msgid " and "
 msgstr " ו-"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:122
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:126
 msgid "Number of accidents by severity"
 msgstr "מספר תאונות לפי חומרה"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:123
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:127
+#: anyway/widgets/road_segment_widgets/accident_count_by_accident_year_widget.py:57
 #: anyway/widgets/road_segment_widgets/accident_count_by_car_type_widget.py:145
 #: anyway/widgets/road_segment_widgets/accident_count_by_hour_widget.py:31
 #: anyway/widgets/road_segment_widgets/accident_count_by_road_light_widget.py:33
 #: anyway/widgets/road_segment_widgets/accidents_heat_map_widget.py:54
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:133
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:53
+#: anyway/widgets/road_segment_widgets/injured_count_by_accident_year_widget.py:56
 #: anyway/widgets/road_segment_widgets/suburban_crosswalk_widget.py:73
 msgid "road_segment_name"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:124
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:128
 msgid "non_urban_intersection_hebrew"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:129
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:149
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:133
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:153
 msgid "Fatal, severe and light accidents count in "
 msgstr "כמות התאונות הקטלניות, הקשות והקלות ב"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:130
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:134
 msgid "segment"
 msgstr "מקטע"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:130
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:157
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:134
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:161
 msgid "junction"
 msgstr "צמת"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:131
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:151
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:173
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:135
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:155
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:177
 msgid "in the selected time"
 msgstr "בפרק הזמן הנבחר"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:137
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:141
 msgid "in years"
 msgstr "בשנים"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:144
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:148
 msgid "{street_name}, {yishuv_name}"
 msgstr ""
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:150
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:154
 msgid "street"
 msgstr "רחוב"
 
-#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:156
+#: anyway/widgets/all_locations_widgets/accident_count_by_severity_widget.py:160
 msgid "Fatal, severe and light accidents count in the specified location."
 msgstr "כמות התאונות הקטלניות, הקשות והקלות במקטע בפרק הזמן הנבחר."
 
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:47
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:49
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:52
-msgid "Severe accidents"
-msgstr "תאונות חמורות"
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:87
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:155
+msgid "one light injured"
+msgstr "פצוע/ה קל"
 
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:51
-#: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:226
-msgid "in"
-msgstr "ב"
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:89
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:156
+msgid "light injured plural"
+msgstr "פצועים/ות קל"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:94
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:153
+msgid "one severe injured"
+msgstr "פצוע/ה קשה"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:96
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:154
+msgid "severe injured plural"
+msgstr "פצועים קשה"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:101
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:151
+msgid "one killed"
+msgstr "הרוג"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:103
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:152
+msgid "killed plural"
+msgstr "הרוגים"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:124
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:149
+msgid "injured/killed"
+msgstr "נפצעו/נהרגו"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:126
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:150
+msgid "people from car accidents"
+msgstr "אנשים מתאונות דרכים"
+
+#: anyway/widgets/all_locations_widgets/injured_count_by_severity_widget.py:140
+msgid "Number of Injuries in accidents by severity"
+msgstr "מספר תאונות לפי חומרה"
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:53
+msgid "Killed and injury stacked per age group"
+msgstr "חומרת פגיעה לפי קבוצת גיל"
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget.py:41
+msgid "Injury per age group"
+msgstr "נפגעים לפי קבוצת גיל"
+
+#: anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget_utils.py:96
+msgid "unknown"
+msgstr "לא ידוע"
 
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:158
 #: anyway/widgets/all_locations_widgets/most_severe_accidents_table_widget.py:227
@@ -551,62 +603,6 @@ msgid ""
 msgstr ""
 "מספר הרוגים, פצועים קשה וקל, לפי שנה במקטע, מחולק לפי חומרת הפגיעה, בפרק "
 "הזמן הנבחר."
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:81
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:146
-msgid "one light injured"
-msgstr "פצוע/ה קל"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:83
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:147
-msgid "light injured plural"
-msgstr "פצועים/ות קל"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:88
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:144
-msgid "one severe injured"
-msgstr "פצוע/ה קשה"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:90
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:145
-msgid "severe injured plural"
-msgstr "פצועים קשה"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:95
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:142
-msgid "one killed"
-msgstr "הרוג"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:97
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:143
-msgid "killed plural"
-msgstr "הרוגים"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:118
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:140
-msgid "injured/killed"
-msgstr "נפצעו/נהרגו"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:120
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:141
-msgid "people from car accidents"
-msgstr "אנשים מתאונות דרכים"
-
-#: anyway/widgets/road_segment_widgets/injured_count_by_severity_widget.py:132
-msgid "Number of Injuries in accidents by severity"
-msgstr "מספר תאונות לפי חומרה"
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_stacked_widget.py:52
-msgid "Killed and injury stacked per age group"
-msgstr "חומרת פגיעה לפי קבוצת גיל"
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_widget.py:39
-msgid "Injury per age group"
-msgstr "נפגעים לפי קבוצת גיל"
-
-#: anyway/widgets/road_segment_widgets/killed_and_injured_count_per_age_group_widget_utils.py:87
-msgid "unknown"
-msgstr "לא ידוע"
 
 #: anyway/widgets/road_segment_widgets/motorcycle_accidents_vs_all_accidents_widget.py:21
 msgid "all roads"


### PR DESCRIPTION
## Changes Made

1. Moved the following widgets from `road_segment_widgets` to `all_location_widgets`:

   - `killed_and_injured_count_per_age_group`
   - `killed_and_injured_count_per_age_group_stacked`
   - `injured_count_by_severity`

2. Fixed the `/api/infographics-data` endpoint's `news_flash_id` argument (reflects the update in the Swagger documentation).

3. Resolved a bug in the histogram within the `killed_and_injured_count_per_age_group` widget. Previously, when there were no accidents with the "unknown" type, the widgets crashed. This issue can be observed in the production logs. For instance, the following API call was successful:

   - https://www.anyway.co.il/api/infographics-data?lang=he&news_flash_id=154488&years_ago=5

   However, the same API call with a 3-year parameter instead of 5 resulted in a crash:

   - https://www.anyway.co.il/api/infographics-data?lang=he&news_flash_id=154488&years_ago=3

   The issue arises when there are no accidents with an "unknown" type within the last 3 years, as all the accident ages are known during that period.
