### PR TITLE
vision_zero_10_50_90_widget bug fix

### DIFF
--- a/anyway/request_params.py
+++ b/anyway/request_params.py
@@ -35,7 +35,7 @@ class RequestParams:
     start_time: datetime.date
     end_time: datetime.date
     lang: str
-    news_flash_description: Optional[str] = None
+    news_flash_description: Optional[str]
     news_flash_title: Optional[str] = None
 
     def __str__(self):

--- a/anyway/request_params.py
+++ b/anyway/request_params.py
@@ -56,7 +56,8 @@ def get_request_params_from_request_values(vals: dict) -> Optional[RequestParams
         else None
     )
     news_flash_title = (
-        news_flash_obj.title if news_flash_obj and news_flash_obj is not None
+        news_flash_obj.title
+        if news_flash_obj is not None and news_flash_obj.title is not None
         else None
     )
     location = get_location_from_news_flash_or_request_values(news_flash_obj, vals)

--- a/anyway/request_params.py
+++ b/anyway/request_params.py
@@ -35,8 +35,8 @@ class RequestParams:
     start_time: datetime.date
     end_time: datetime.date
     lang: str
-    news_flash_description: Optional[str]
-    news_flash_title: Optional[str]
+    news_flash_description: Optional[str] = None
+    news_flash_title: Optional[str] = None
 
     def __str__(self):
         return (

--- a/anyway/request_params.py
+++ b/anyway/request_params.py
@@ -36,6 +36,7 @@ class RequestParams:
     end_time: datetime.date
     lang: str
     news_flash_description: Optional[str]
+    news_flash_title: Optional[str]
 
     def __str__(self):
         return (
@@ -52,6 +53,10 @@ def get_request_params_from_request_values(vals: dict) -> Optional[RequestParams
     news_flash_description = (
         news_flash_obj.description
         if news_flash_obj is not None and news_flash_obj.description is not None
+        else None
+    )
+    news_flash_title = (
+        news_flash_obj.title if news_flash_obj and news_flash_obj is not None
         else None
     )
     location = get_location_from_news_flash_or_request_values(news_flash_obj, vals)
@@ -98,6 +103,7 @@ def get_request_params_from_request_values(vals: dict) -> Optional[RequestParams
         end_time=end_time,
         lang=lang,
         news_flash_description=news_flash_description,
+        news_flash_title=news_flash_title,
     )
     logging.debug(f"Ending get_request_params. params: {request_params}")
     return request_params

--- a/anyway/widgets/urban_widgets/vision_zero_10_50_90_widget.py
+++ b/anyway/widgets/urban_widgets/vision_zero_10_50_90_widget.py
@@ -24,6 +24,8 @@ class VisionZero105090Widget(UrbanWidget):
         for pedestrian_adjective in ["הולך רגל", "הולכת רגל", "הולכי רגל", "הולכות רגל"]:
             if self.request_params.news_flash_description and pedestrian_adjective in self.request_params.news_flash_description:
                 return True
+            if self.request_params.news_flash_title and pedestrian_adjective in self.request_params.news_flash_title:
+                return True
         return False
 
 


### PR DESCRIPTION
Problem:
The is_included method did not include checking for pedestrian keywords within the news flash title (it only checked the news flash description).
Fix:
Added "news_flash_title" to the request_params and modified is_included accordingly.