### PR TITLE
Widget vision_zero_bike is_included fix

### DIFF
--- a/anyway/widgets/no_location_widgets/vision_zero_bike_widget.py
+++ b/anyway/widgets/no_location_widgets/vision_zero_bike_widget.py
@@ -25,8 +25,10 @@ class VisionZeroBikeWidget(Widget):
 
     # noinspection PyUnboundLocalVariable
     def is_included(self) -> bool:
-        if self.request_params.news_flash_description:
-            return "אופניים" in self.request_params.news_flash_description
+        if self.request_params.news_flash_description and "אופניים" in self.request_params.news_flash_description:
+            return True
+        if self.request_params.news_flash_title and "אופניים" in self.request_params.news_flash_title:
+            return True
         return False
 
     @staticmethod


### PR DESCRIPTION
Problem:
The is_included method did not include checking for bicycle keywords within the news flash title (it only checked the news flash description).
Fix:
Modified is_included accordingly