### PR TITLE
Fix killed_and_injured_count_per_age_group ranges order

### DIFF
--- a/anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget_utils.py
+++ b/anyway/widgets/all_locations_widgets/killed_and_injured_count_per_age_group_widget_utils.py
@@ -63,6 +63,12 @@ class KilledAndInjuredCountPerAgeGroupWidgetUtils:
             return lambda: defaultdict(int)
 
         dict_grouped = defaultdict(defaultdict_int_factory())
+        # initialize the dict for fixed order of the ranges
+        for item_min_range, item_max_range in AGE_RANGE_DICT.items():
+            for injury_id in InjurySeverity.codes():
+                string_age_range = f"{item_min_range:02}-{item_max_range:02}"
+                dict_grouped[string_age_range][injury_id] = 0
+
         has_data = False
         for row in query:
             has_data = True


### PR DESCRIPTION
This pull request resolves the problem of inconsistent order for ranges within the widgets killed_and_injured_count_per_age_group and killed_and_injured_count_per_age_group_stacked when data are absent.

Example of the bug: 

![image](https://github.com/data-for-change/anyway/assets/62066172/88009cc5-d55d-4d09-9cf1-f8b6ec00416e)
