### PR TITLE
add option to update_cbs_location_only

### DIFF
--- a/anyway/parsers/__init__.py
+++ b/anyway/parsers/__init__.py
@@ -4,7 +4,7 @@ resolution_dict = {
     "עיר": ["yishuv_name"],
     "רחוב": ["yishuv_name", "street1_hebrew"],
     "צומת עירוני": ["yishuv_name", "street1_hebrew", "street2_hebrew"],
-    "כביש בינעירוני": ["road1", "road_segment_name", "road_segment_id"],
+    "כביש בינעירוני": ["road1", "road_segment_name"],
     "צומת בינעירוני": ["non_urban_intersection", "non_urban_intersection_hebrew", "road1", "road2"],
     "אחר": [
         "region_hebrew",

--- a/anyway/parsers/__init__.py
+++ b/anyway/parsers/__init__.py
@@ -4,7 +4,7 @@ resolution_dict = {
     "עיר": ["yishuv_name"],
     "רחוב": ["yishuv_name", "street1_hebrew"],
     "צומת עירוני": ["yishuv_name", "street1_hebrew", "street2_hebrew"],
-    "כביש בינעירוני": ["road1", "road_segment_name"],
+    "כביש בינעירוני": ["road1", "road_segment_name", "road_segment_id"],
     "צומת בינעירוני": ["non_urban_intersection", "non_urban_intersection_hebrew", "road1", "road2"],
     "אחר": [
         "region_hebrew",

--- a/anyway/parsers/location_extraction.py
+++ b/anyway/parsers/location_extraction.py
@@ -506,18 +506,25 @@ def extract_location_text(text):
     return text
 
 
-def extract_geo_features(db, newsflash: NewsFlash) -> None:
-    newsflash.location = extract_location_text(newsflash.description) or extract_location_text(
-        newsflash.title
-    )
-    geo_location = geocode_extract(newsflash.location)
-    if geo_location is not None:
-        newsflash.lat = geo_location["geom"]["lat"]
-        newsflash.lon = geo_location["geom"]["lng"]
-        newsflash.resolution = set_accident_resolution(geo_location)
+def extract_geo_features(db, newsflash: NewsFlash, update_cbs_location_only: bool) -> None:
+    location_from_db = None
+    if update_cbs_location_only:
         location_from_db = get_db_matching_location(
+                db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
+            )
+    else:
+        newsflash.location = extract_location_text(newsflash.description) or extract_location_text(
+            newsflash.title
+        )
+        geo_location = geocode_extract(newsflash.location)
+        if geo_location is not None:
+            newsflash.lat = geo_location["geom"]["lat"]
+            newsflash.lon = geo_location["geom"]["lng"]
+            newsflash.resolution = set_accident_resolution(geo_location)
+            location_from_db = get_db_matching_location(
             db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
         )
+    if location_from_db is not None:
         for k, v in location_from_db.items():
             setattr(newsflash, k, v)
         all_resolutions = []

--- a/anyway/parsers/location_extraction.py
+++ b/anyway/parsers/location_extraction.py
@@ -510,7 +510,7 @@ def extract_geo_features(db, newsflash: NewsFlash, update_cbs_location_only: boo
     location_from_db = None
     if update_cbs_location_only:
         location_from_db = get_db_matching_location(
-            db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
+            db, newsflash.lat, newsflash.lon, newsflash.resolution, newsflash.road1
         )
     else:
         newsflash.location = extract_location_text(newsflash.description) or extract_location_text(

--- a/anyway/parsers/location_extraction.py
+++ b/anyway/parsers/location_extraction.py
@@ -510,8 +510,8 @@ def extract_geo_features(db, newsflash: NewsFlash, update_cbs_location_only: boo
     location_from_db = None
     if update_cbs_location_only:
         location_from_db = get_db_matching_location(
-                db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
-            )
+            db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
+        )
     else:
         newsflash.location = extract_location_text(newsflash.description) or extract_location_text(
             newsflash.title
@@ -522,8 +522,8 @@ def extract_geo_features(db, newsflash: NewsFlash, update_cbs_location_only: boo
             newsflash.lon = geo_location["geom"]["lng"]
             newsflash.resolution = set_accident_resolution(geo_location)
             location_from_db = get_db_matching_location(
-            db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
-        )
+                db, newsflash.lat, newsflash.lon, newsflash.resolution, geo_location["road_no"]
+            )
     if location_from_db is not None:
         for k, v in location_from_db.items():
             setattr(newsflash, k, v)

--- a/anyway/parsers/news_flash.py
+++ b/anyway/parsers/news_flash.py
@@ -14,7 +14,7 @@ from anyway.parsers.location_extraction import extract_geo_features
 news_flash_classifiers = {"ynet": classify_rss, "twitter": classify_tweets, "walla": classify_rss}
 
 
-def update_all_in_db(source=None, newsflash_id=None):
+def update_all_in_db(source=None, newsflash_id=None, update_cbs_location_only=False):
     """
     main function for newsflash updating.
 
@@ -29,11 +29,15 @@ def update_all_in_db(source=None, newsflash_id=None):
         newsflash_items = db.get_all_newsflash()
 
     for newsflash in newsflash_items:
-        classify = news_flash_classifiers[newsflash.source]
-        newsflash.organization = classify_organization(newsflash.source)
-        newsflash.accident = classify(newsflash.description or newsflash.title)
-        if newsflash.accident:
-            extract_geo_features(db, newsflash)
+        if update_cbs_location_only:
+            if newsflash.accident:
+                extract_geo_features(db, newsflash, update_cbs_location_only=True)
+        else:
+            classify = news_flash_classifiers[newsflash.source]
+            newsflash.organization = classify_organization(newsflash.source)
+            newsflash.accident = classify(newsflash.description or newsflash.title)
+            if newsflash.accident:
+                extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only=False)
     db.commit()
 
 

--- a/anyway/parsers/news_flash.py
+++ b/anyway/parsers/news_flash.py
@@ -34,7 +34,9 @@ def update_all_in_db(source=None, newsflash_id=None, update_cbs_location_only=Fa
             newsflash.organization = classify_organization(newsflash.source)
             newsflash.accident = classify(newsflash.description or newsflash.title)
         if newsflash.accident:
-            extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only=update_cbs_location_only)
+            extract_geo_features(
+                db=db, newsflash=newsflash, update_cbs_location_only=update_cbs_location_only
+            )
     db.commit()
 
 

--- a/anyway/parsers/news_flash.py
+++ b/anyway/parsers/news_flash.py
@@ -29,15 +29,12 @@ def update_all_in_db(source=None, newsflash_id=None, update_cbs_location_only=Fa
         newsflash_items = db.get_all_newsflash()
 
     for newsflash in newsflash_items:
-        if update_cbs_location_only:
-            if newsflash.accident:
-                extract_geo_features(db, newsflash, update_cbs_location_only=True)
-        else:
+        if not update_cbs_location_only:
             classify = news_flash_classifiers[newsflash.source]
             newsflash.organization = classify_organization(newsflash.source)
             newsflash.accident = classify(newsflash.description or newsflash.title)
-            if newsflash.accident:
-                extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only=False)
+        if newsflash.accident:
+            extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only)
     db.commit()
 
 

--- a/anyway/parsers/news_flash.py
+++ b/anyway/parsers/news_flash.py
@@ -34,7 +34,7 @@ def update_all_in_db(source=None, newsflash_id=None, update_cbs_location_only=Fa
             newsflash.organization = classify_organization(newsflash.source)
             newsflash.accident = classify(newsflash.description or newsflash.title)
         if newsflash.accident:
-            extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only)
+            extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only=update_cbs_location_only)
     db.commit()
 
 

--- a/anyway/parsers/news_flash.py
+++ b/anyway/parsers/news_flash.py
@@ -51,7 +51,7 @@ def scrape_extract_store_rss(site_name, db):
         newsflash.organization = classify_organization(site_name)
         if newsflash.accident:
             # FIX: No accident-accurate date extracted
-            extract_geo_features(db, newsflash)
+            extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only=False)
             newsflash.set_critical()
         db.insert_new_newsflash(newsflash)
 
@@ -65,7 +65,7 @@ def scrape_extract_store_twitter(screen_name, db):
         newsflash.accident = classify_tweets(newsflash.description)
         newsflash.organization = classify_organization("twitter")
         if newsflash.accident:
-            extract_geo_features(db, newsflash)
+            extract_geo_features(db=db, newsflash=newsflash, update_cbs_location_only=False)
             newsflash.set_critical()
         db.insert_new_newsflash(newsflash)
 

--- a/anyway/parsers/news_flash_db_adapter.py
+++ b/anyway/parsers/news_flash_db_adapter.py
@@ -3,6 +3,7 @@ import os
 import logging
 import pandas as pd
 import numpy as np
+from sqlalchemy import desc
 from flask_sqlalchemy import SQLAlchemy
 from anyway.parsers import infographics_data_cache_updater
 from anyway.parsers import timezones
@@ -111,7 +112,7 @@ class DBAdapter:
         return self.db.session.query(NewsFlash).filter(NewsFlash.source == source)
 
     def get_all_newsflash(self):
-        return self.db.session.query(NewsFlash)
+        return self.db.session.query(NewsFlash).order_by(desc(NewsFlash.date))
 
     def get_latest_date_of_source(self, source):
         """

--- a/main.py
+++ b/main.py
@@ -67,14 +67,15 @@ def update_news_flash():
 @update_news_flash.command()
 @click.option("--source", default="", type=str)
 @click.option("--news_flash_id", default="", type=str)
-def update(source, news_flash_id):
+@click.option("--update_cbs_location_only", is_flag=True)
+def update(source, news_flash_id, update_cbs_location_only):
     from anyway.parsers import news_flash
 
     if not source:
         source = None
     if not news_flash_id:
         news_flash_id = None
-    return news_flash.update_all_in_db(source, news_flash_id)
+    return news_flash.update_all_in_db(source, news_flash_id, update_cbs_location_only)
 
 
 @update_news_flash.command()


### PR DESCRIPTION
@ziv17 this is required to update historical news flash location once we update the new road segments in production (in that case queries will be by this new road segments table)

I also created a separate issue to add road_segment_id in resolution_dict (so news flash will be updated with it): https://github.com/data-for-change/anyway/issues/2564 I think this issue requires testing hence created a different issue for it