### PR TITLE
Add nbconvert and ipykernel for schools notebook on server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,5 @@ matplotlib==3.5.3
 shapely==1.8.5
 holidays==0.19
 tqdm==4.64.1
+nbconvert==7.16.4
+ipykernel==6.29.5


### PR DESCRIPTION
## Summary
- Add `nbconvert==7.16.4` and `ipykernel==6.29.5` so the schools report notebook can be executed on the server
- Pinned to versions that still support Python 3.8